### PR TITLE
Remove 'Download this Appstore' link in the navbar

### DIFF
--- a/aslo4-static/about.html
+++ b/aslo4-static/about.html
@@ -58,9 +58,6 @@
             <a class="nav-link" href="https://github.com/srevinsaju/sugar-activity-build#adding-your-bundles-xo">Add Activities</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://github.com/srevinsaju/sugar-activity-build/releases/download/latest/saas.tar.gz">Download this appstore</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="https://github.com/srevinsaju/sugar-activity-build"><i class="fa fa-github"></i></a>
           </li>
           <!--li class="nav-item dropdown">

--- a/aslo4-static/index.html
+++ b/aslo4-static/index.html
@@ -89,9 +89,6 @@
             <a class="nav-link" href="https://github.com/srevinsaju/sugar-activity-build#adding-your-bundles-xo">Add Activities</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://github.com/srevinsaju/sugar-activity-build/releases/download/latest/saas.tar.gz">Download this appstore</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="/about.html">How it works?</a>
           </li>
           <li class="nav-item">


### PR DESCRIPTION
Fixes #19

It might be dangerous to allow a user to download the entire appstore
without understanding how it works. See #19 for a detailed information