### PR TITLE
Optionally show headings and error message

### DIFF
--- a/aslo4/constants.py
+++ b/aslo4/constants.py
@@ -55,7 +55,7 @@ CAROUSEL_HTML_TEMPLATE = \
 """
 
 FLATPAK_HTML_TEMPLATE = \
-"""<div class="card text-white bg-info mb-3" style="border-radius: 1rem;">
+    """<div class="card text-white bg-info mb-3" style="border-radius: 1rem;">
   <div class="card-header"><i class="fa fa-box" aria-hidden="true"></i> Flatpak</div>
   <div class="card-body">
     <h5 class="card-title">{activity_name} Activity is also available as a flatpak!</h5>
@@ -68,8 +68,24 @@ FLATPAK_HTML_TEMPLATE = \
     </a>
 </div></div>"""
 
-HTML_TEMPLATE = """
-<!DOCTYPE html>
+CHANGELOG_HTML_TEMPLATE = \
+    """<div class="saas-activity-changelog">
+  <h4>Changelog</h4>
+  <pre class="pre-scrollable"><code>{changelog}</code></pre>
+</div>"""
+
+NEW_FEATURE_HTML_TEMPLATE = \
+    """<h4>New in this Version</h4>
+<ul>{new_features}</ul>
+</div>"""
+
+DESCRIPTION_HTML_TEMPLATE = \
+    """<div class="saas-activity-card-description" id=description>
+<h3>Description</h3>
+<p>{description}</p>
+</div>"""
+
+HTML_TEMPLATE = """<!DOCTYPE html>
 <html>
   <head>
     <title>{title} - Sugar AppStore</title>
@@ -111,10 +127,7 @@ HTML_TEMPLATE = """
               <h3>Summary</h3>
               <p>{summary}</p>
             </div>
-            <div class="saas-activity-card-description" id=description>
-              <h3>Description</h3>
-              <p>{description}</p>
-            </div>
+            {description_html_div}
             <div class="saas-activity-card-tags" id="authors">
               <h3>Authors</h3>
               {author_list_html_formatted}
@@ -124,15 +137,8 @@ HTML_TEMPLATE = """
               {tag_list_html_formatted}
             </div>
             <div class="saas-activity-new-features">
-              <h4>New in this Version</h4>
-              <ul>
-               {new_features}
-              </ul>
-            </div>
-            <div class="saas-activity-changelog">
-              <h4>Changelog</h4>
-              <pre class="pre-scrollable"><code>{changelog}</code></pre>
-            </div>
+            {new_feature_html_div}
+            {changelog_html_div}
             {flatpak_html_div}
             <a href="{git_url}" class="btn btn-secondary saas-activity-download-button"
             style="margin-bottom: 0.25rem">
@@ -154,14 +160,14 @@ HTML_TEMPLATE = """
 """
 
 SITEMAP_HEADER = \
-"""<?xml version="1.0" encoding="UTF-8"?>
+    """<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {content}
 </urlset>
 """
 
 SITEMAP_URL = \
-"""<url>
+    """<url>
   <loc>{url}</loc>
   <lastmod>{lastmod}</lastmod>
   <changefreq>{changefreq}</changefreq>

--- a/aslo4/generator.py
+++ b/aslo4/generator.py
@@ -711,7 +711,6 @@ class SaaSBuild:
             else:
                 changelog_formatted_html = ''
 
-
             # get the HTML_TEMPLATE and annotate with the saved
             # information
             debug("[STATIC][{}] Generating static HTML".format(

--- a/aslo4/generator.py
+++ b/aslo4/generator.py
@@ -31,7 +31,8 @@ import sys
 import zipfile
 
 from .bundle.bundle import Bundle
-from .constants import HTML_TEMPLATE
+from .constants import HTML_TEMPLATE, CHANGELOG_HTML_TEMPLATE, \
+    NEW_FEATURE_HTML_TEMPLATE
 from .constants import SITEMAP_HEADER
 from .constants import SITEMAP_URL
 from .constants import FLATPAK_HTML_TEMPLATE
@@ -632,7 +633,7 @@ class SaaSBuild:
             # Changelog gen
             debug("[STATIC][{}] Processing news".format(bundle.get_name()))
             changelog_latest_version = bundle.get_news()
-            html_changelog_latest_version = \
+            new_in_this_version_raw_html = \
                 self._process_changelog_html(changelog_latest_version)
 
             # changelog all
@@ -696,6 +697,21 @@ class SaaSBuild:
                         output_dir
                     )
 
+            if len(new_in_this_version_raw_html):
+                new_in_this_version_parsed = NEW_FEATURE_HTML_TEMPLATE.format(
+                    new_features=''.join(new_in_this_version_raw_html)
+                )
+            else:
+                new_in_this_version_parsed = ''
+
+            if changelog:
+                changelog_formatted_html = CHANGELOG_HTML_TEMPLATE.format(
+                    changelog=''.join(new_in_this_version_raw_html)
+                )
+            else:
+                changelog_formatted_html = ''
+
+
             # get the HTML_TEMPLATE and annotate with the saved
             # information
             debug("[STATIC][{}] Generating static HTML".format(
@@ -705,7 +721,7 @@ class SaaSBuild:
                 version=bundle.get_version(),
                 summary=bundle.get_summary(),
                 licenses=''.join(html_parsed_licenses),
-                description='Nothing here yet!',
+                description_html_div='',
                 # TODO: Extract from README.md
                 bundle_path='../bundles/{}'.format(
                     _bundle_path.split(os.path.sep)[-1]),
@@ -713,8 +729,8 @@ class SaaSBuild:
                 author_list_html_formatted=''.join(authors_html_list),
                 icon_path='../icons/{}'.format(
                     _icon_path.split(os.path.sep)[-1]),
-                new_features=''.join(html_changelog_latest_version),
-                changelog=changelog,
+                new_feature_html_div=new_in_this_version_parsed,
+                changelog_html_div=changelog_formatted_html,
                 git_url=bundle.get_git_url(),
                 flatpak_html_div=flatpak_html_div,
                 carousel=carousel_div


### PR DESCRIPTION
ASLOv4 always showed 'no description found' message whenever description / changelog / new in this feature was missing or failed to parse. In such cases, it was better to not show the message and hide that section. Improves accessibility

Fixes #27