### PR TITLE
Do not add Bots as authors

### DIFF
--- a/aslo4/bundle/bundle.py
+++ b/aslo4/bundle/bundle.py
@@ -657,7 +657,15 @@ class Bundle:
 
         else:
             authors = self.create_authors_log_file().split('\n')
-        unique_authors = set(authors)
+
+        bots_file = os.path.join(os.path.dirname(
+                os.path.dirname(__file__)), 'data', 'bots.txt')
+        if os.path.exists(bots_file):
+            with open(bots_file, 'r') as fp:
+                bots = fp.read().split('\n')
+        else:
+            bots = set()
+        unique_authors = set(authors).difference(bots)
         author_db = dict()
         for author in unique_authors:
             author_db[author] = authors.count(author)

--- a/aslo4/data/bots.txt
+++ b/aslo4/data/bots.txt
@@ -1,0 +1,2 @@
+translation server
+Pootle daemon


### PR DESCRIPTION
Fixes #23
Some git authors are robots, so they don't need credit.
Suggested by @quozl

From this commit, a new file ./aslo5/data/bots.txt is added to the project data files
the project looks for that data file and reads bots.txt and takes the set difference of the existing git authors
For adding more bot authors, a new line containing the name of the bot can be added to bots.txt;