### PR TITLE
Modify CSS to center the download button and increase padding

### DIFF
--- a/aslo4-static/css/main.css
+++ b/aslo4-static/css/main.css
@@ -9,10 +9,6 @@
   padding: 1rem;
 }
 
-.saas-activity-download-button {
-  border-radius: 1rem;
-}
-
 .saas-activity-card-image {
   height: 25vh;
   width: 25vh;
@@ -27,4 +23,12 @@
   margin: 0.2rem !important;
   font-size: 1em !important;
   padding: 0.3rem !important;
+}
+
+.saas-activity-download-button {
+  max-width: 550px;
+  text-align: center;
+  margin: 1em auto;
+  padding: 1em 2em;
+  border-radius: 1rem;
 }

--- a/aslo4/constants.py
+++ b/aslo4/constants.py
@@ -115,6 +115,9 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             alt="Logo of the activity {title}">
             </img>
             <h1 class="card-title text-center">{title}</h1>
+            <a type="application/zip" href="{bundle_path}" class="btn btn-primary saas-activity-download-button">
+              <i class="fa fa-download"></i> Download
+            </a>
             <div class="saas-activity-card-version mx-auto">
               <span class="badge badge-success saas-badge">
               Version <span class="badge badge-dark">{version}</span>
@@ -122,9 +125,6 @@ HTML_TEMPLATE = """<!DOCTYPE html>
               License {licenses}
               </span>
             </div>
-            <a type="application/zip" href="{bundle_path}" class="btn btn-primary saas-activity-download-button">
-              <i class="fa fa-download"></i> Download
-            </a>
             {carousel}
             <div class="saas-activity-card-summary" id=summary>
               <h3>Summary</h3>

--- a/aslo4/constants.py
+++ b/aslo4/constants.py
@@ -115,9 +115,6 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             alt="Logo of the activity {title}">
             </img>
             <h1 class="card-title text-center">{title}</h1>
-            <a type="application/zip" href="{bundle_path}" class="btn btn-primary saas-activity-download-button">
-              <i class="fa fa-download"></i> Download
-            </a>
             <div class="saas-activity-card-version mx-auto">
               <span class="badge badge-success saas-badge">
               Version <span class="badge badge-dark">{version}</span>
@@ -125,6 +122,9 @@ HTML_TEMPLATE = """<!DOCTYPE html>
               License {licenses}
               </span>
             </div>
+            <a type="application/zip" href="{bundle_path}" class="btn btn-primary saas-activity-download-button">
+              <i class="fa fa-download"></i> Download
+            </a>
             {carousel}
             <div class="saas-activity-card-summary" id=summary>
               <h3>Summary</h3>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48695438/92236830-e61bcd00-eebe-11ea-9ea5-0462999dedfb.png)

This was what @quozl committed on https://github.com/sugarlabs-appstore/aslo-v4/commit/e927a617e2417bd7d38af09e1c60881bc6fd739d

I modified it on https://github.com/sugarlabs-appstore/aslo-v4/pull/40/commits/d373900b722bb42ace56fd687f05dc9453966085 to make it look like this 

![](https://user-images.githubusercontent.com/48695438/92236656-81f90900-eebe-11ea-8e34-adb5493bc9f4.png)

@quozl If it looks satisfactory, please merge to [is-25-promote-download](https://github.com/sugarlabs-appstore/aslo-v4/tree/is-25-promote-download)